### PR TITLE
Add temporary hack to enable/disable running of unit tests; will be r…

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -51,6 +51,14 @@ env = Environment( CPPPATH   = [ includePath, ],
                    BINDIR    = bindir,
                   )
 
+# Temporary hack to enable/disable running of tests.  To run the tests:
+#   scons --run-tests=True
+# Will be reimplemented with phony targets
+AddOption('--run-tests', dest='runTests',
+          nargs=1,default=False,
+          help='--run-tests=[True,False] enables/disables running tests')
+env['RUNTESTS'] = GetOption("runTests")
+
 # Modify the environment: set compile and link flags.
 SetOption('warn', 'no-fortran-cxx-mix')
 env.MergeFlags( defineMergeFlags(debugLevel) )

--- a/UnitTests/SConscript
+++ b/UnitTests/SConscript
@@ -27,7 +27,9 @@ linkLists = {
 
 helper.make_unit_tests ( linkLists )
 
-helper.run_unit_tests()
+if env['RUNTESTS']:
+    print ("Running unit tests" )
+    helper.run_unit_tests()
 
 
 # This tells emacs to view this file in python mode.

--- a/scripts/newBuild.sh
+++ b/scripts/newBuild.sh
@@ -46,7 +46,7 @@ fi
 package_source=`cd "$(dirname ${BASH_SOURCE})" >/dev/null 2>&1 && /bin/pwd | sed -e 's|/scripts$||' `
 echo $package_source
 
-cp ${package_source}/SConstruct .
+ln -s ${package_source}/SConstruct .
 
 cat >> setup.sh <<EOF
 #


### PR DESCRIPTION
Add temporary hack to enable/disable running of unit tests.  The longer term plan is to reimplement the unit test system using phony targets.